### PR TITLE
added more prefix support, last ditch preview

### DIFF
--- a/handler/handler.go
+++ b/handler/handler.go
@@ -12,19 +12,30 @@ import (
 // Parses the url and appends .json to it
 func ParseUrl(raw string) (url, title string, err error) {
 
-	valid_prefix := "https://www.reddit.com/r/"
-
-	// if it doesnt have a valid prefix then its probably not a reddit url
-	if !strings.HasPrefix(raw, valid_prefix) {
-		err = fmt.Errorf("url should start with '%s'", valid_prefix)
-		return "", "", err
-	}
-
 	utility.InfoLog.Println("Parsing The URL")
 
-	subdomain := strings.Replace(raw, "www.reddit.com", "old.reddit.com", -1)
+	/*
+		this supports:
+		https://www.reddit.com/r/...
+		https://reddit.com/r/...
+		http://www.reddit.com/r/...
+		http://reddit.com/r/...
+		www.reddit.com/r/...
+		reddit.com/r/...
+	*/
+	if !(strings.Contains(raw, "http://") || strings.Contains(raw, "https://")) {
+		// No protocol was provided, append a https:// to the start of the url.
+		raw = "https://" + raw
+	}
 
-	split_url := strings.Split(subdomain, "?")[0]
+	// drop the 1st occourance of www.
+	raw = strings.Replace(raw, "www.", "", 1)
+	// and replace the 1st occourance of reddit.com with old.reddit.com
+	raw = strings.Replace(raw, "reddit.com", "old.reddit.com", 1)
+
+	// if it fails after those, the url that was sent is likely nonsense.
+
+	split_url := strings.Split(raw, "?")[0]
 
 	// remove any trailing slashes
 	trim_url := strings.TrimSuffix(split_url, "/")

--- a/model/models.go
+++ b/model/models.go
@@ -7,6 +7,7 @@ type Reddit []struct {
 				MediaMetadata       mediaMetadata          `json:"media_metadata,omitempty"`
 				SecureMedia         secureMedia            `json:"secure_media,omitempty"`
 				CrossPost           []*crosspostParentList `json:"crosspost_parent_list,omitempty"`
+				Preview             preview                `json:"preview,omitempty"`
 				URLOverriddenByDest string                 `json:"url_overridden_by_dest"`
 			} `json:"data"`
 		} `json:"children"`
@@ -18,6 +19,21 @@ type secureMedia struct {
 	Oembed      *oembed      `json:"oembed,omitempty"`
 }
 
+type preview struct {
+	Images []struct {
+		Variants struct {
+			GIF *struct {
+				Source struct {
+					URL string `json:"url"`
+				} `json:"source"`
+			} `json:"gif"`
+		} `json:"variants"`
+	} `json:"images"`
+
+	Video *struct {
+		FallbackURL string `json:"fallback_url"`
+	} `json:"reddit_video_preview"`
+}
 type redditVideo struct {
 	FallbackURL string `json:"fallback_url"`
 	HLS         string `json:"hls_url"`


### PR DESCRIPTION
Instead of checking if the prefix of the url is "https://www.reddit.com/r/", which can lead to some bugs (using www.reddit.com) will still say it's invalid, now we do check if there is a protocol, either http or https, and we replace www. with nothing and reddit.com with old.reddit.com

Also implemented a Preview struct (basically, a last ditch effort to grab the gif / video - as if you tried the url from #1, it would've errored out (unsupported provider)

As for unsupported providers, instead of the default case returning nothing, it now prints an error, and tries the fallback options

Final changes are in GetMediaUrl, as I replace the amp; in the urls with nothing, and instead of using HasSuffix on the .gif, I replaced it with Contains (as the GIF Variant of the fallback url also contains an s query.)